### PR TITLE
Also handle "Jade" syntax for legacy reasons

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class PugLint(NodeLinter):
     """Provides an interface to pug-lint."""
 
     npm_name = 'pug-lint'
-    syntax = 'pug'
+    syntax = ('pug', 'jade')
     cmd = 'pug-lint @ *'
     executable = None
     version_args = '--version'


### PR DESCRIPTION
Allow syntax in SublimeText to be set to either "Pug" (for when the SublimeText language mode is updated) or "Jade" (which is what it's still currently called).

Otherwise, linting breaks for existing files/projects, even if you update from jade-lint to pug-lint
