### PR TITLE
Move attribute to "selector" in defaults from "syntax", as suggested by SublimeLinter

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,6 @@ class PugLint(NodeLinter):
     """Provides an interface to pug-lint."""
 
     npm_name = 'pug-lint'
-    syntax = ('pug', 'jade')
     cmd = 'pug-lint @ *'
     executable = None
     version_args = '--version'
@@ -28,5 +27,8 @@ class PugLint(NodeLinter):
     tempfile_suffix = 'pug'
     error_stream = util.STREAM_BOTH
     config_file = ('--config', '.pug-lintrc', '.pug-lint.json', '.jade-lintrc', '.jade-lint.json', '~')
-    defaults = {'--reporter=': 'inline'}
+    defaults = {
+        'selector': 'text.pug, source.pypug, text.jade',
+        '--reporter=': 'inline'
+    }
     default_type = highlight.WARNING


### PR DESCRIPTION
This PR is to fix the warning by SublimeLinter in Sublime Text 3:

```
Defining 'cls.syntax' has been deprecated. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector
```

Also add support of `source.pypug`.

Thanks