### PR TITLE
Update to Catch Up The Sublime Linter API:

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,8 +19,8 @@ class PugLint(NodeLinter):
     cmd = 'pug-lint ${temp_file} ${args}'
     regex = r'^.+?:(?P<line>\d+)(:(?P<col>\d+) | )(?P<message>.+)'
     multiline = False
+    on_stderr = None
     tempfile_suffix = 'pug'
-    error_stream = util.STREAM_BOTH
     defaults = {
         'selector': 'text.pug, source.pypug, text.jade',
         '--reporter=': 'inline'

--- a/linter.py
+++ b/linter.py
@@ -18,11 +18,10 @@ class PugLint(NodeLinter):
 
     cmd = 'pug-lint ${temp_file} ${args}'
     regex = r'^.+?:(?P<line>\d+)(:(?P<col>\d+) | )(?P<message>.+)'
-    multiline = False
     on_stderr = None
     tempfile_suffix = 'pug'
     defaults = {
         'selector': 'text.pug, source.pypug, text.jade',
-        '--reporter=': 'inline'
+        '--reporter': 'inline'
     }
     default_type = WARNING

--- a/linter.py
+++ b/linter.py
@@ -10,13 +10,13 @@
 
 """This module exports the PugLint plugin class."""
 
-from SublimeLinter.lint import NodeLinter, util, highlight
+from SublimeLinter.lint import NodeLinter, WARNING
 
 
 class PugLint(NodeLinter):
     """Provides an interface to pug-lint."""
 
-    cmd = 'pug-lint @ *'
+    cmd = 'pug-lint ${temp_file} ${args}'
     regex = r'^.+?:(?P<line>\d+)(:(?P<col>\d+) | )(?P<message>.+)'
     multiline = False
     tempfile_suffix = 'pug'
@@ -25,4 +25,4 @@ class PugLint(NodeLinter):
         'selector': 'text.pug, source.pypug, text.jade',
         '--reporter=': 'inline'
     }
-    default_type = highlight.WARNING
+    default_type = WARNING


### PR DESCRIPTION
- Use `WARNING` instead of `util` and `hightlight`.
- Update `cmd` key to meet the requirement of Sublime Linter
- The Linter panel can properly show "warnings" now

Solves #10 . Specially thanks @pykong for tips. :pizza:

Didn't notice the previous commit will trigger a merge. Not sure how version update will affect deployments. Hopefully I can catch up! Sorry for inconvenience!